### PR TITLE
Make individual error prop boolean and sync parent and child state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaskaairux/auro-checkbox",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/auro-checkbox-group.js
+++ b/src/auro-checkbox-group.js
@@ -55,13 +55,31 @@ class AuroCheckboxGroup extends LitElement {
     this.items.forEach((el) => {
       el.disabled = this.disabled;
       el.required = this.required;
+      el.error = Boolean(this.error);
     });
   }
 
-  errorChange() {
-    this.items.forEach((el) => {
-      el.error = Boolean(this.error)
-    });
+  /**
+   * LitElement lifecycle method. Called after the DOM has been updated.
+   * @param {Map<string, any>} changedProperties - keys are the names of changed properties, values are the corresponding previous values.
+   * @returns {void}
+   */
+   updated(changedProperties) {
+    if (changedProperties.has('disabled')) {
+      this.items.forEach((el) => {
+        el.disabled = this.disabled
+      });
+    }
+    if (changedProperties.has('required')) {
+      this.items.forEach((el) => {
+        el.required = this.required
+      });
+    }
+    if (changedProperties.has('error')) {
+      this.items.forEach((el) => {
+        el.error = Boolean(this.error)
+      });
+    }
   }
 
   render() {
@@ -70,8 +88,6 @@ class AuroCheckboxGroup extends LitElement {
     }
 
     return html`
-      ${this.errorChange()}
-
       <fieldset class="${classMap(groupClasses)}">
         ${this.required
           ? html`<legend><slot name="legend"></slot></legend>`

--- a/src/auro-checkbox.js
+++ b/src/auro-checkbox.js
@@ -18,6 +18,7 @@ class AuroCheckbox extends LitElement {
     this.checked = false;
     this.disabled = false;
     this.required = false;
+    this.error = false;
   }
 
   static get styles() {

--- a/src/auro-checkbox.js
+++ b/src/auro-checkbox.js
@@ -42,7 +42,7 @@ class AuroCheckbox extends LitElement {
         reflect: true
       },
       error: {
-        type: String,
+        type: Boolean,
         reflect: true
       },
       id:       { type: String },
@@ -85,7 +85,7 @@ class AuroCheckbox extends LitElement {
     const labelClasses = {
       'label': true,
       'label--cbx': true,
-      'errorBorder': Boolean(this.error)
+      'errorBorder': this.error
     }
 
     return html`

--- a/src/auro-checkbox.scss
+++ b/src/auro-checkbox.scss
@@ -19,7 +19,7 @@
   display: block;
 }
 
-:host([error='true']) {
+:host([error]) {
   color: var(--auro-color-text-error-on-light);
 }
 

--- a/test/auro-checkbox.test.js
+++ b/test/auro-checkbox.test.js
@@ -149,8 +149,7 @@ describe('auro-checkbox', () => {
   it('has the expected properties', async () => {
     const expectedId = "testId",
       expectedName = "testName",
-      expectedValue = "testValue",
-      expectedError = "testError";
+      expectedValue = "testValue";
 
     const el = await fixture(html`
       <auro-checkbox
@@ -160,7 +159,7 @@ describe('auro-checkbox', () => {
         checked
         disabled
         required
-        error="${expectedError}"
+        error
       >Checkbox option</auro-checkbox>
     `);
 
@@ -173,10 +172,12 @@ describe('auro-checkbox', () => {
     expect(input.value).to.equal(expectedValue);
     expect(input.name).to.equal(expectedName);
     expect(input.type).to.equal('checkbox');
+    expect(input.getAttribute('aria-invalid')).to.equal('true');
+    expect(input.getAttribute('aria-required')).to.equal('true');
     expect(errorBorder).to.not.be.undefined;
     expect(el).dom.to.equal(`
-    <auro-checkbox id="${expectedId}" name="${expectedName}" value="${expectedValue}" error="${expectedError}" checked disabled required>
-      Checkbox option
-    </auro-checkbox>`);
-  });
+      <auro-checkbox id="${expectedId}" name="${expectedName}" value="${expectedValue}" error checked disabled required>
+        Checkbox option
+      </auro-checkbox>`);
+    });
 });

--- a/test/auro-checkbox.test.js
+++ b/test/auro-checkbox.test.js
@@ -97,9 +97,9 @@ describe('auro-checkbox-group', () => {
     expect(washingtonCheckbox.checked).to.be.true;
   });
 
-  it('controls disabled state after slot change', async () => {
+  it('controls child state after slot change', async () => {
     const el = await fixture(html`
-      <auro-checkbox-group disabled></auro-checkbox-group>
+      <auro-checkbox-group disabled required error="Test message"></auro-checkbox-group>
     `);
 
     // render children after the group has connected
@@ -119,10 +119,11 @@ describe('auro-checkbox-group', () => {
     const checkbox = el.querySelector('auro-checkbox');
 
     expect(checkbox.disabled).to.be.true;
+    expect(checkbox.required).to.be.true;
+    expect(checkbox.error).to.be.true;
   });
 
   it('is accessible', async () => {
-
     const el = await fixture(html`
       <auro-checkbox-group>
         <auro-checkbox
@@ -142,6 +143,38 @@ describe('auro-checkbox-group', () => {
     `);
 
     expect(el).to.be.accessible();
+  });
+
+  it('updates states on children', async () => {
+    const el = await fixture(html`
+      <auro-checkbox-group>
+        <auro-checkbox
+          id="alaska"
+          name="states"
+          value="alaska"
+          checked
+        ></auro-checkbox>
+
+        <auro-checkbox
+          id="washington"
+          name="states"
+          type="radio"
+          value="washington"
+        ></auro-checkbox>
+      </auro-checkbox-group>
+    `);
+
+    el.disabled = true;
+    el.required = true;
+    el.error = "This is an error";
+
+    await elementUpdated(el);
+
+    const checkbox = el.querySelector('auro-checkbox');
+
+    expect(checkbox.disabled, "child disabled state was not updated").to.be.true;
+    expect(checkbox.required, "child required state was not updated").to.be.true;
+    expect(checkbox.error, "child error state was not updated").to.be.true;
   });
 });
 

--- a/test/auro-checkbox.test.js
+++ b/test/auro-checkbox.test.js
@@ -31,42 +31,6 @@ describe('auro-checkbox-group', () => {
       Checkbox option
     </auro-checkbox-group>`);
   });
-});
-
-describe('auro-checkbox', () => {
-  it('has the expected properties', async () => {
-    const expectedId = "testId",
-      expectedName = "testName",
-      expectedValue = "testValue",
-      expectedError = "testError";
-
-    const el = await fixture(html`
-      <auro-checkbox
-        id="${expectedId}"
-        name="${expectedName}"
-        value="${expectedValue}"
-        checked
-        disabled
-        required
-        error="${expectedError}"
-      >Checkbox option</auro-checkbox>
-    `);
-
-    const root = el.shadowRoot;
-    const input = root.querySelector('input');
-    const errorBorder = root.querySelector('.errorBorder');
-
-    expect(input.checked).to.be.true;
-    expect(input.disabled).to.be.true;
-    expect(input.value).to.equal(expectedValue);
-    expect(input.name).to.equal(expectedName);
-    expect(input.type).to.equal('checkbox');
-    expect(errorBorder).to.not.be.undefined;
-    expect(el).dom.to.equal(`
-    <auro-checkbox id="${expectedId}" name="${expectedName}" value="${expectedValue}" error="${expectedError}" checked disabled required>
-      Checkbox option
-    </auro-checkbox>`);
-  });
 
   it('should fire a input event with correct data', async () => {
     const el = await fixture(html`
@@ -178,5 +142,41 @@ describe('auro-checkbox', () => {
     `);
 
     expect(el).to.be.accessible();
+  });
+});
+
+describe('auro-checkbox', () => {
+  it('has the expected properties', async () => {
+    const expectedId = "testId",
+      expectedName = "testName",
+      expectedValue = "testValue",
+      expectedError = "testError";
+
+    const el = await fixture(html`
+      <auro-checkbox
+        id="${expectedId}"
+        name="${expectedName}"
+        value="${expectedValue}"
+        checked
+        disabled
+        required
+        error="${expectedError}"
+      >Checkbox option</auro-checkbox>
+    `);
+
+    const root = el.shadowRoot;
+    const input = root.querySelector('input');
+    const errorBorder = root.querySelector('.errorBorder');
+
+    expect(input.checked).to.be.true;
+    expect(input.disabled).to.be.true;
+    expect(input.value).to.equal(expectedValue);
+    expect(input.name).to.equal(expectedName);
+    expect(input.type).to.equal('checkbox');
+    expect(errorBorder).to.not.be.undefined;
+    expect(el).dom.to.equal(`
+    <auro-checkbox id="${expectedId}" name="${expectedName}" value="${expectedValue}" error="${expectedError}" checked disabled required>
+      Checkbox option
+    </auro-checkbox>`);
   });
 });


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes #31 
Fixes #33

## Summary:

- The `error` property on individual checkboxes is now a boolean in line with existing documentation
- When the parent's disabled or required state updates, the children are also updated using the [updated lifecycle](https://lit.dev/docs/components/lifecycle/#updated) method.
- Refactor existing error state handling to use the above method.
- Set error state when a new item is added to the slot.
- Refactor tests so that all group tests are in the same `describe` block.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
