### PR TITLE
fix: use checked property instead of attribute

### DIFF
--- a/src/auro-checkbox.js
+++ b/src/auro-checkbox.js
@@ -98,7 +98,7 @@ class AuroCheckbox extends LitElement {
           ?disabled="${this.disabled}"
           aria-invalid="${this.invalid(this.error)}"
           aria-required="${this.isRequired(this.required)}"
-          ?checked="${this.checked}"
+          .checked="${this.checked}"
           id="${ifDefined(this.id)}"
           name="${ifDefined(this.name)}"
           type="checkbox"

--- a/test/auro-checkbox.test.js
+++ b/test/auro-checkbox.test.js
@@ -62,6 +62,27 @@ describe('auro-checkbox-group', () => {
     expect(result).to.be.true;
   });
 
+  it('can uncheck a checkbox after selection', async () => {
+    const el = await fixture(html`
+      <auro-checkbox
+        id="alaska"
+        name="states-unchecking"
+        value="alaska"
+      ></auro-checkbox>
+    `),
+    alaskaCheckbox = el,
+    alaskaCheckboxInput = alaskaCheckbox.shadowRoot.querySelector('input');
+
+    alaskaCheckboxInput.click();
+    alaskaCheckboxInput.dispatchEvent(new Event('input'));
+    await alaskaCheckbox.updateComplete;
+    expect(alaskaCheckboxInput.checked).to.be.true;
+
+    alaskaCheckbox.checked = false;
+    await alaskaCheckbox.updateComplete;
+    expect(alaskaCheckboxInput.checked, 'the shadow input was not unchecked').to.be.false;
+  });
+
   it('can select multiple checkboxes', async () => {
     const el = await fixture(html`
       <auro-checkbox-group>


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes #42

## Summary:

Set the `checked` property on the underlying input instead of the attribute. This ensures that programmatic updates to the checkbox are preserved, e.g. setting checked to false after the user has interacted with the checkbox.

I added a unit test to capture this case. I don't anticipate any issues with this change.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
