### PR TITLE
Correct 'engines' property in package.json to align with other Auro projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "main": "index.js",
   "license": "Apache-2.0",
   "engines": {
-    "node": "<=v12.22.6"
+    "node": ">=v12.22.6"
   },
   "dependencies": {
     "chalk": "^4.1.2",


### PR DESCRIPTION
# Alaska Airlines Pull Request

Changed the allowed version ranges of node in `"engines"` property of `package.json` to allow versions 12+ to install the project.

**Fixes:** #60 

## Summary:

This aligns with other recently-updated Auro projects that specify the `"engines"` property.

## Type of change:

Please delete options that are not relevant.

- [ ] New capability
- [ ] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [X] Bug

This affects consumers who wish to `npm install` the library, or contributors who wish to work on it in their local development environment.

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**